### PR TITLE
(FEAT) エラーハンドリングの実装

### DIFF
--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -7,7 +7,6 @@ const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError,
 
 export const Button = () => {
   const { state, dispatch } = React.useContext(PlayContext);
-  console.log(state.hasWordError);
 
   const handleOnClick = () => {
     let lastCharacter: string = state.lastWord.slice(-1);
@@ -67,7 +66,6 @@ export const Button = () => {
             if (tokens.length === 0 || tokens.length > 1) {
               dispatch(checkWordError(true));
               dispatch(setWordErrorMessage("一単語だけ入力してください。"));
-              console.log("呼ばれたよ");
               return;
             }
             if (tokens[0].word_type === 'UNKNOWN') {
@@ -93,7 +91,6 @@ export const Button = () => {
 
     if(state.inputWord){
       // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
-      console.log(state.inputWord);
       changeToHiragana(state.inputWord)
       .then((data: string): void => {
         console.log(data);
@@ -101,6 +98,8 @@ export const Button = () => {
       })
       .then((): void => {
         if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
+          dispatch(checkWordError(false));
+          dispatch(setWordErrorMessage(""));
           dispatch(verifyJapaneseWord(true));
           console.log("the input word can follow the previous word!");
         };

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,15 +1,123 @@
-interface Props {
-  text: string;
-  onClick: () => void;
-}
+import React from "react";
+import { PlayContext } from "../pages/Play/Play";
+import { actions } from "reducers/play";
+import kuromoji from "kuromoji";
 
-export const Button = ({ text, onClick }: Props) => {
+const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
+
+export const Button = () => {
+  const { state, dispatch } = React.useContext(PlayContext);
+  console.log(state.hasWordError);
+
+  const handleOnClick = () => {
+    let lastCharacter: string = state.lastWord.slice(-1);
+    let hiraganaInputWord: string = "";
+
+    // 前の単語が特殊文字で終了する場合の最終文字の変形処理
+    if (state.lastWord) {
+      
+      if (lastCharacter === 'ー') {
+        lastCharacter = state.lastWord.slice(0, -1).slice(-1);
+      }
+      switch(lastCharacter) {
+        case 'ぁ':
+            lastCharacter = 'あ';
+            break;
+        case 'ぃ':
+            lastCharacter = 'い';
+            break;
+        case 'ぅ':
+            lastCharacter = 'う';
+            break;
+        case 'ぇ':
+            lastCharacter = 'え';
+            break;
+        case 'ぉ':
+            lastCharacter = 'お';
+            break;
+        case 'っ':
+            lastCharacter = 'つ';
+            break;
+        case 'ゃ':
+            lastCharacter = 'や';
+            break;
+        case 'ゅ':
+            lastCharacter = 'ゆ';
+            break;
+        case 'ょ':
+            lastCharacter = 'よ';
+            break;
+        case 'ゎ':
+            lastCharacter = 'わ';
+            break;
+        default:
+      }
+    }
+
+    // kuromojiを使って入力単語をひらがなに変換する処理
+    const changeToHiragana = (text: string) => {
+      return new Promise<string> ((resolve, reject) => {
+        kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
+          if(error){
+            reject(error);
+            return;
+          } else {
+            const tokens: any[] = tokenizer.tokenize(text);
+            console.log(tokens);
+            if (tokens.length === 0 || tokens.length > 1) {
+              dispatch(checkWordError(true));
+              dispatch(setWordErrorMessage("一単語だけ入力してください。"));
+              console.log("呼ばれたよ");
+              return;
+            }
+            if (tokens[0].word_type === 'UNKNOWN') {
+              dispatch(checkWordError(true));
+              dispatch(setWordErrorMessage("実際に存在する単語を入力してください。"));
+              return;
+            }
+            if (!tokens[0].reading) {
+              dispatch(checkWordError(true));
+              dispatch(setWordErrorMessage("認識できませんでした。別の単語を入力してください。"));
+              return;
+            }
+            let reading: string = tokens[0].reading;
+            const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
+              const chr = match.charCodeAt(0) - 0x60;
+              return String.fromCharCode(chr);
+            });
+            resolve(hiragana);
+          }
+        })
+      })
+    }
+
+    if(state.inputWord){
+      // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
+      console.log(state.inputWord);
+      changeToHiragana(state.inputWord)
+      .then((data: string): void => {
+        console.log(data);
+        hiraganaInputWord = data;
+      })
+      .then((): void => {
+        if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
+          dispatch(verifyJapaneseWord(true));
+          console.log("the input word can follow the previous word!");
+        };
+        if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
+          dispatch(checkWordError(true));
+          dispatch(setWordErrorMessage("前の単語につながりません。"));
+        };
+      })
+    }
+  }
+
   return (
     <button
       className='mt-20 w-48 rounded-full border-2 border-accent bg-transparent py-4 px-6 font-bold text-white hover:bg-accent md:w-60'
-      onClick={onClick}
+      onClick={handleOnClick}
     >
-      <span className='font-nico text-3xl'>{text}</span>
+      <span className='font-nico text-3xl'>{"つなげる"}</span>
     </button>
   );
 };

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -89,6 +89,12 @@ export const Button = () => {
       })
     }
 
+    // 入力が無い場合のエラー
+    if(!state.inputWord) {
+      dispatch(checkWordError(true));
+      dispatch(setWordErrorMessage("単語を入力してください。"));
+    }
+
     if(state.inputWord){
       // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
       changeToHiragana(state.inputWord)

--- a/web/src/components/Button.tsx
+++ b/web/src/components/Button.tsx
@@ -1,128 +1,15 @@
-import React from "react";
-import { PlayContext } from "../pages/Play/Play";
-import { actions } from "reducers/play";
-import kuromoji from "kuromoji";
+interface Props {
+  text: string;
+  onClick: () => void;
+}
 
-const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
-
-export const Button = () => {
-  const { state, dispatch } = React.useContext(PlayContext);
-
-  const handleOnClick = () => {
-    let lastCharacter: string = state.lastWord.slice(-1);
-    let hiraganaInputWord: string = "";
-
-    // 前の単語が特殊文字で終了する場合の最終文字の変形処理
-    if (state.lastWord) {
-      
-      if (lastCharacter === 'ー') {
-        lastCharacter = state.lastWord.slice(0, -1).slice(-1);
-      }
-      switch(lastCharacter) {
-        case 'ぁ':
-            lastCharacter = 'あ';
-            break;
-        case 'ぃ':
-            lastCharacter = 'い';
-            break;
-        case 'ぅ':
-            lastCharacter = 'う';
-            break;
-        case 'ぇ':
-            lastCharacter = 'え';
-            break;
-        case 'ぉ':
-            lastCharacter = 'お';
-            break;
-        case 'っ':
-            lastCharacter = 'つ';
-            break;
-        case 'ゃ':
-            lastCharacter = 'や';
-            break;
-        case 'ゅ':
-            lastCharacter = 'ゆ';
-            break;
-        case 'ょ':
-            lastCharacter = 'よ';
-            break;
-        case 'ゎ':
-            lastCharacter = 'わ';
-            break;
-        default:
-      }
-    }
-
-    // kuromojiを使って入力単語をひらがなに変換する処理
-    const changeToHiragana = (text: string) => {
-      return new Promise<string> ((resolve, reject) => {
-        kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
-          if(error){
-            reject(error);
-            return;
-          } else {
-            const tokens: any[] = tokenizer.tokenize(text);
-            console.log(tokens);
-            if (tokens.length === 0 || tokens.length > 1) {
-              dispatch(checkWordError(true));
-              dispatch(setWordErrorMessage("一単語だけ入力してください。"));
-              return;
-            }
-            if (tokens[0].word_type === 'UNKNOWN') {
-              dispatch(checkWordError(true));
-              dispatch(setWordErrorMessage("実際に存在する単語を入力してください。"));
-              return;
-            }
-            if (!tokens[0].reading) {
-              dispatch(checkWordError(true));
-              dispatch(setWordErrorMessage("認識できませんでした。別の単語を入力してください。"));
-              return;
-            }
-            let reading: string = tokens[0].reading;
-            const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
-              const chr = match.charCodeAt(0) - 0x60;
-              return String.fromCharCode(chr);
-            });
-            resolve(hiragana);
-          }
-        })
-      })
-    }
-
-    // 入力が無い場合のエラー
-    if(!state.inputWord) {
-      dispatch(checkWordError(true));
-      dispatch(setWordErrorMessage("単語を入力してください。"));
-    }
-
-    if(state.inputWord){
-      // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
-      changeToHiragana(state.inputWord)
-      .then((data: string): void => {
-        console.log(data);
-        hiraganaInputWord = data;
-      })
-      .then((): void => {
-        if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
-          dispatch(checkWordError(false));
-          dispatch(setWordErrorMessage(""));
-          dispatch(verifyJapaneseWord(true));
-          console.log("the input word can follow the previous word!");
-        };
-        if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
-          dispatch(checkWordError(true));
-          dispatch(setWordErrorMessage("前の単語につながりません。"));
-        };
-      })
-    }
-  }
-
+export const Button = ({ text, onClick }: Props) => {
   return (
     <button
       className='mt-20 w-48 rounded-full border-2 border-accent bg-transparent py-4 px-6 font-bold text-white hover:bg-accent md:w-60'
-      onClick={handleOnClick}
+      onClick={onClick}
     >
-      <span className='font-nico text-3xl'>{"つなげる"}</span>
+      <span className='font-nico text-3xl'>{text}</span>
     </button>
   );
 };

--- a/web/src/components/WordInput.tsx
+++ b/web/src/components/WordInput.tsx
@@ -1,12 +1,20 @@
-interface Props {
-  onChangeAction: (input:string) => void
-}
+import React from "react";
+import { PlayContext } from "../pages/Play/Play";
+import { actions } from "reducers/play";
 
-export const WordInput = ({ onChangeAction }: Props) => {
+const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
+
+export const WordInput = () => {
+  const { state, dispatch } = React.useContext(PlayContext);
+
+  const handleWordChange = (input: string) => {
+    dispatch(setInputWord(input));
+  };
+
   return (
     <div className='mt-5'>
       <input
-        onChange={e => onChangeAction(e.currentTarget.value)}
+        onChange={e => handleWordChange(e.currentTarget.value)}
         type='text'
         className='h-20 w-80 border-b-2 border-transparent border-b-accent bg-transparent px-4 font-nico text-xl focus:border-accent focus:ring-0 md:w-96'
         placeholder='「ご」につづく単語を入れよう!'

--- a/web/src/components/WordInput.tsx
+++ b/web/src/components/WordInput.tsx
@@ -1,20 +1,12 @@
-import React from "react";
-import { PlayContext } from "../pages/Play/Play";
-import { actions } from "reducers/play";
+interface Props {
+  onChangeAction: (input:string) => void
+}
 
-const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
-
-export const WordInput = () => {
-  const { state, dispatch } = React.useContext(PlayContext);
-
-  const handleWordChange = (input: string) => {
-    dispatch(setInputWord(input));
-  };
-
+export const WordInput = ({ onChangeAction }: Props) => {
   return (
     <div className='mt-5'>
       <input
-        onChange={e => handleWordChange(e.currentTarget.value)}
+        onChange={e => onChangeAction(e.currentTarget.value)}
         type='text'
         className='h-20 w-80 border-b-2 border-transparent border-b-accent bg-transparent px-4 font-nico text-xl focus:border-accent focus:ring-0 md:w-96'
         placeholder='「ご」につづく単語を入れよう!'

--- a/web/src/pages/Play/Play.tsx
+++ b/web/src/pages/Play/Play.tsx
@@ -1,11 +1,16 @@
 import { Button } from "components/Button";
 import { Navbar } from "components/Navbar";
 import { WordInput } from "components/WordInput";
+import { State, Actions, initialState, reducer } from "reducers/play";
+import React, { useReducer, createContext } from "react";
 
-import useHandleAction from "./hooks";
+export const PlayContext = createContext({} as {
+  state: State;
+  dispatch: React.Dispatch<Actions>;
+})
 
 const Play = () => {
-  const { handleWordChange, handleOnClick } = useHandleAction();
+  const [state, dispatch] = useReducer(reducer, initialState);
 
   return (
     <>
@@ -22,8 +27,11 @@ const Play = () => {
           className='h-20 md:h-auto'
         />
         <div className='flex flex-col items-center justify-center'>
-          <WordInput onChangeAction={handleWordChange} />
-          <Button text={"つなげる"} onClick={handleOnClick} />
+          <PlayContext.Provider value={{ state, dispatch }}>
+            <WordInput />
+            {state.hasWordError && <div>{state.wordErrorMessage}</div>}
+            <Button />
+          </PlayContext.Provider>
         </div>
       </div>
     </>

--- a/web/src/pages/Play/Play.tsx
+++ b/web/src/pages/Play/Play.tsx
@@ -29,7 +29,7 @@ const Play = () => {
         <div className='flex flex-col items-center justify-center'>
           <PlayContext.Provider value={{ state, dispatch }}>
             <WordInput />
-            {state.hasWordError && <div>{state.wordErrorMessage}</div>}
+            {state.hasWordError && <p className='text-red-500 text-center md:text-xl mt-5'>{state.wordErrorMessage}</p>}
             <Button />
           </PlayContext.Provider>
         </div>

--- a/web/src/pages/Play/Play.tsx
+++ b/web/src/pages/Play/Play.tsx
@@ -1,16 +1,18 @@
 import { Button } from "components/Button";
 import { Navbar } from "components/Navbar";
 import { WordInput } from "components/WordInput";
-import { State, Actions, initialState, reducer } from "reducers/play";
-import React, { useReducer, createContext } from "react";
 
-export const PlayContext = createContext({} as {
-  state: State;
-  dispatch: React.Dispatch<Actions>;
-})
+import useHandleAction from "./hooks";
 
 const Play = () => {
-  const [state, dispatch] = useReducer(reducer, initialState);
+  const {
+    handleWordChange,
+    handleOnClick,
+    isValidJapanese,
+    inputWord,
+    hasWordError,
+    wordErrorMessage,
+  } = useHandleAction();
 
   return (
     <>
@@ -27,11 +29,9 @@ const Play = () => {
           className='h-20 md:h-auto'
         />
         <div className='flex flex-col items-center justify-center'>
-          <PlayContext.Provider value={{ state, dispatch }}>
-            <WordInput />
-            {state.hasWordError && <p className='text-red-500 text-center md:text-xl mt-5'>{state.wordErrorMessage}</p>}
-            <Button />
-          </PlayContext.Provider>
+          <WordInput onChangeAction={handleWordChange} />
+          {hasWordError && <p className='text-red-500 text-center md:text-xl mt-5'>{wordErrorMessage}</p>}
+          <Button text={"つなげる"} onClick={handleOnClick} />
         </div>
       </div>
     </>

--- a/web/src/pages/Play/hooks.ts
+++ b/web/src/pages/Play/hooks.ts
@@ -1,161 +1,149 @@
-import React from "react";
+import { useEffect, useReducer } from "react";
+import { actions, initialState, reducer } from "reducers/play";
+import kuromoji from "kuromoji";
 
-// 本ファイルは使用していない
-// 了承確認後、削除予定
+const {
+  setLastWord,
+  setInputWord,
+  verifyJapaneseWord,
+  setError,
+  checkWordError,
+  setWordErrorMessage,
+} = actions;
 
-// import { actions, initialState, reducer } from "reducers/play";
-// // import kuromoji from "kuromoji";
+const useHandleAction = () => {
+  const [state, dispatch] = useReducer(reducer, initialState);
 
-// const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
+  const handleWordChange = (input: string) => {
+    dispatch(setInputWord(input));
+  };
 
-// const useHandleAction = () => {
-//   const [state, dispatch] = useReducer(reducer, initialState);
-  
+  const handleOnClick = () => {
+    let lastCharacter: string = state.lastWord.slice(-1);
+    let hiraganaInputWord: string = "";
 
-//   console.log(errorState.hasWordError);
+    // 前の単語が特殊文字で終了する場合の最終文字の変形処理
+    if (state.lastWord) {
+      if (lastCharacter === "ー") {
+        lastCharacter = state.lastWord.slice(0, -1).slice(-1);
+      }
+      switch (lastCharacter) {
+        case "ぁ":
+          lastCharacter = "あ";
+          break;
+        case "ぃ":
+          lastCharacter = "い";
+          break;
+        case "ぅ":
+          lastCharacter = "う";
+          break;
+        case "ぇ":
+          lastCharacter = "え";
+          break;
+        case "ぉ":
+          lastCharacter = "お";
+          break;
+        case "っ":
+          lastCharacter = "つ";
+          break;
+        case "ゃ":
+          lastCharacter = "や";
+          break;
+        case "ゅ":
+          lastCharacter = "ゆ";
+          break;
+        case "ょ":
+          lastCharacter = "よ";
+          break;
+        case "ゎ":
+          lastCharacter = "わ";
+          break;
+        default:
+      }
+    }
 
-//   const handleWordChange = (input: string) => {
-//     dispatch(setInputWord(input));
-//   };
+    if (state.inputWord) {
+      // kuromojiを使って入力単語をひらがなに変換する処理
+      const changeToHiragana = (text: string) => {
+        return new Promise<string>((resolve, reject) => {
+          kuromoji
+            .builder({ dicPath: "/dict" })
+            .build((error: Error, tokenizer: any) => {
+              if (error) {
+                reject(error);
+                return;
+              } else {
+                const tokens: any[] = tokenizer.tokenize(text);
+                console.log(tokens);
+                if (tokens.length === 0 || tokens.length > 1) {
+                  dispatch(checkWordError(true));
+                  dispatch(setWordErrorMessage("一単語だけ入力してください。"));
+                  return;
+                }
+                if (tokens[0].word_type === "UNKNOWN") {
+                  dispatch(checkWordError(true));
+                  dispatch(
+                    setWordErrorMessage(
+                      "実際に存在する単語を入力してください。"
+                    )
+                  );
+                  return;
+                }
+                if (!tokens[0].reading) {
+                  dispatch(checkWordError(true));
+                  dispatch(
+                    setWordErrorMessage(
+                      "認識できませんでした。別の単語を入力してください。"
+                    )
+                  );
+                  return;
+                }
+                let reading: string = tokens[0].reading;
+                const hiragana: string = reading.replace(
+                  /[\u30a1-\u30f6]/g,
+                  function (match: string) {
+                    const chr = match.charCodeAt(0) - 0x60;
+                    return String.fromCharCode(chr);
+                  }
+                );
+                resolve(hiragana);
+              }
+            });
+        });
+      };
 
-//   const handleOnClick = () => {
-//     let lastCharacter: string = state.lastWord.slice(-1);
-//     let hiraganaInputWord: string = "";
+      // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
+      changeToHiragana(state.inputWord)
+        .then((data: string): void => {
+          console.log(data);
+          hiraganaInputWord = data;
+        })
+        .then((): void => {
+          if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
+            dispatch(checkWordError(false));
+            dispatch(setWordErrorMessage(""));
+            dispatch(verifyJapaneseWord(true));
+            console.log("the input word can follow the previous word!");
+          }
+          if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
+            dispatch(checkWordError(true));
+            dispatch(setWordErrorMessage("前の単語につながりません。"));
+          }
+        });
+    }
+  };
 
-//     // 前の単語が特殊文字で終了する場合の最終文字の変形処理
-//     if (state.lastWord) {
-      
-//       if (lastCharacter === 'ー') {
-//         lastCharacter = state.lastWord.slice(0, -1).slice(-1);
-//       }
-//       switch(lastCharacter) {
-//         case 'ぁ':
-//             lastCharacter = 'あ';
-//             break;
-//         case 'ぃ':
-//             lastCharacter = 'い';
-//             break;
-//         case 'ぅ':
-//             lastCharacter = 'う';
-//             break;
-//         case 'ぇ':
-//             lastCharacter = 'え';
-//             break;
-//         case 'ぉ':
-//             lastCharacter = 'お';
-//             break;
-//         case 'っ':
-//             lastCharacter = 'つ';
-//             break;
-//         case 'ゃ':
-//             lastCharacter = 'や';
-//             break;
-//         case 'ゅ':
-//             lastCharacter = 'ゆ';
-//             break;
-//         case 'ょ':
-//             lastCharacter = 'よ';
-//             break;
-//         case 'ゎ':
-//             lastCharacter = 'わ';
-//             break;
-//         default:
-//       }
-//     }
+  useEffect(() => {
+    // TODO: 現状の最後の単語をfetchするfunctionを入れる
+  });
 
-//     // kuromojiを使って入力単語をひらがなに変換する処理
-//     const changeToHiragana = (text: string) => {
-//       return new Promise<string> ((resolve, reject) => {
-//         kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
-//           if(error){
-//             reject(error);
-//             return;
-//           } else {
-//             const tokens: any[] = tokenizer.tokenize(text);
-//             console.log(tokens);
-//             if (tokens.length === 0 || tokens.length > 1) {
-//               errorDispatch({
-//                 type: "CHECK_WORD_ERROR",
-//                 payload: true
-//               });
-//               errorDispatch({
-//                 type: "SET_WORD_ERROR_MESSAGE",
-//                 payload: "一単語だけ入力してください。"
-//               });
-//               console.log("呼ばれたよ");
-//               return;
-//             }
-//             if (tokens[0].word_type === 'UNKNOWN') {
-//               errorDispatch({
-//                 type: "CHECK_WORD_ERROR",
-//                 payload: true
-//               });
-//               errorDispatch({
-//                 type: "SET_WORD_ERROR_MESSAGE",
-//                 payload: "実際に存在する単語を入力してください。"
-//               });
-//               return;
-//             }
-//             if (!tokens[0].reading) {
-//               errorDispatch({
-//                 type: "CHECK_WORD_ERROR",
-//                 payload: true
-//               });
-//               errorDispatch({
-//                 type: "SET_WORD_ERROR_MESSAGE",
-//                 payload: "認識できませんでした。別の単語を入力してください。"
-//               });
-//               return;
-//             }
-//             let reading: string = tokens[0].reading;
-//             const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
-//               const chr = match.charCodeAt(0) - 0x60;
-//               return String.fromCharCode(chr);
-//             });
-//             resolve(hiragana);
-//           }
-//         })
-//       })
-//     }
+  // TODO: 入力した単語をsetするfunction
 
-//     if(state.inputWord){
-//       // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
-//       console.log(state.inputWord);
-//       changeToHiragana(state.inputWord)
-//       .then((data: string): void => {
-//         console.log(data);
-//         hiraganaInputWord = data;
-//       })
-//       .then((): void => {
-//         if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
-//           dispatch(verifyJapaneseWord(true));
-//           console.log("the input word can follow the previous word!");
-//         };
-//         if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
-//           errorDispatch({
-//             type: "CHECK_WORD_ERROR",
-//             payload: true
-//           });
-//           errorDispatch({
-//             type: "SET_WORD_ERROR_MESSAGE",
-//             payload: "前の単語につながりません。"
-//           });
-//         };
-//       })
-//     }
-//   }
-  
-//   useEffect(() => {
-//     // TODO: 現状の最後の単語をfetchするfunctionを入れる
-//   });
+  return {
+    ...state,
+    handleWordChange: handleWordChange,
+    handleOnClick: handleOnClick,
+  };
+};
 
-//   // TODO: 入力した単語をsetするfunction
-
-//   return {
-//     ...state,
-//     handleWordChange: handleWordChange,
-//     handleOnClick: handleOnClick
-//   };
-// };
-
-// export default useHandleAction;
+export default useHandleAction;

--- a/web/src/pages/Play/hooks.ts
+++ b/web/src/pages/Play/hooks.ts
@@ -15,6 +15,8 @@ const useHandleAction = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const handleWordChange = (input: string) => {
+    dispatch(checkWordError(false));
+    dispatch(setWordErrorMessage(""));
     dispatch(setInputWord(input));
   };
 
@@ -112,8 +114,6 @@ const useHandleAction = () => {
         })
         .then((): void => {
           if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
-            dispatch(checkWordError(false));
-            dispatch(setWordErrorMessage(""));
             dispatch(verifyJapaneseWord(true));
             console.log("the input word can follow the previous word!");
           }

--- a/web/src/pages/Play/hooks.ts
+++ b/web/src/pages/Play/hooks.ts
@@ -1,111 +1,145 @@
-import { useEffect, useReducer } from "react";
+import React, { useEffect, useReducer } from "react";
 import { actions, initialState, reducer } from "reducers/play";
-import kuromoji from "kuromoji";
+// import kuromoji from "kuromoji";
 
-const { setLastWord, setInputWord, verifyJapaneseWord, setError } = actions;
+const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
 
 const useHandleAction = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
+  
 
-  const handleWordChange = (input: string) => {
-    dispatch(setInputWord(input));
-  };
+  // console.log(errorState.hasWordError);
 
-  const handleOnClick = () => {
-    let lastCharacter: string = state.lastWord.slice(-1);
-    let hiraganaInputWord: string = "";
+  // const handleWordChange = (input: string) => {
+  //   dispatch(setInputWord(input));
+  // };
 
-    // 前の単語が特殊文字で終了する場合の最終文字の変形処理
-    if (state.lastWord) {
+  // const handleOnClick = () => {
+  //   let lastCharacter: string = state.lastWord.slice(-1);
+  //   let hiraganaInputWord: string = "";
+
+  //   // 前の単語が特殊文字で終了する場合の最終文字の変形処理
+  //   if (state.lastWord) {
       
-      if (lastCharacter === 'ー') {
-        lastCharacter = state.lastWord.slice(0, -1).slice(-1);
-      }
-      switch(lastCharacter) {
-        case 'ぁ':
-            lastCharacter = 'あ';
-            break;
-        case 'ぃ':
-            lastCharacter = 'い';
-            break;
-        case 'ぅ':
-            lastCharacter = 'う';
-            break;
-        case 'ぇ':
-            lastCharacter = 'え';
-            break;
-        case 'ぉ':
-            lastCharacter = 'お';
-            break;
-        case 'っ':
-            lastCharacter = 'つ';
-            break;
-        case 'ゃ':
-            lastCharacter = 'や';
-            break;
-        case 'ゅ':
-            lastCharacter = 'ゆ';
-            break;
-        case 'ょ':
-            lastCharacter = 'よ';
-            break;
-        case 'ゎ':
-            lastCharacter = 'わ';
-            break;
-        default:
-      }
-    }
+  //     if (lastCharacter === 'ー') {
+  //       lastCharacter = state.lastWord.slice(0, -1).slice(-1);
+  //     }
+  //     switch(lastCharacter) {
+  //       case 'ぁ':
+  //           lastCharacter = 'あ';
+  //           break;
+  //       case 'ぃ':
+  //           lastCharacter = 'い';
+  //           break;
+  //       case 'ぅ':
+  //           lastCharacter = 'う';
+  //           break;
+  //       case 'ぇ':
+  //           lastCharacter = 'え';
+  //           break;
+  //       case 'ぉ':
+  //           lastCharacter = 'お';
+  //           break;
+  //       case 'っ':
+  //           lastCharacter = 'つ';
+  //           break;
+  //       case 'ゃ':
+  //           lastCharacter = 'や';
+  //           break;
+  //       case 'ゅ':
+  //           lastCharacter = 'ゆ';
+  //           break;
+  //       case 'ょ':
+  //           lastCharacter = 'よ';
+  //           break;
+  //       case 'ゎ':
+  //           lastCharacter = 'わ';
+  //           break;
+  //       default:
+  //     }
+  //   }
 
-    if(state.inputWord){
-      // kuromojiを使って入力単語をひらがなに変換する処理
-      const changeToHiragana = (text: string) => {
-        return new Promise<string> ((resolve, reject) => {
-          kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
-            if(error){
-              reject(error);
-              return;
-            } else {
-              const tokens: any[] = tokenizer.tokenize(text);
-              console.log(tokens);
-              if (tokens.length === 0 || tokens.length > 1) {
-                console.log("Please input one word.");
-                return;
-              }
-              if (tokens[0].word_type === 'UNKNOWN') {
-                console.log("Please input KNOWN word.");
-                return;
-              }
-              if (!tokens[0].reading) {
-                return;
-              }
-              let reading: string = tokens[0].reading;
-              const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
-                const chr = match.charCodeAt(0) - 0x60;
-                return String.fromCharCode(chr);
-              });
-              resolve(hiragana);
-            }
-          })
-        })
-      }
-      
-      // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
-      changeToHiragana(state.inputWord)
-      .then((data: string): void => {
-        console.log(data);
-        hiraganaInputWord = data;
-      })
-      .then((): void => {
-        if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
-          dispatch(verifyJapaneseWord(true));
-          console.log("the input word can follow the previous word!");
-        };
-        if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
-          console.log("the input word cannot follow the previous word!")
-        };
-      })
-    }
-  }
+  //   // kuromojiを使って入力単語をひらがなに変換する処理
+  //   const changeToHiragana = (text: string) => {
+  //     return new Promise<string> ((resolve, reject) => {
+  //       kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
+  //         if(error){
+  //           reject(error);
+  //           return;
+  //         } else {
+  //           const tokens: any[] = tokenizer.tokenize(text);
+  //           console.log(tokens);
+  //           if (tokens.length === 0 || tokens.length > 1) {
+  //             errorDispatch({
+  //               type: "CHECK_WORD_ERROR",
+  //               payload: true
+  //             });
+  //             errorDispatch({
+  //               type: "SET_WORD_ERROR_MESSAGE",
+  //               payload: "一単語だけ入力してください。"
+  //             });
+  //             console.log("呼ばれたよ");
+  //             return;
+  //           }
+  //           if (tokens[0].word_type === 'UNKNOWN') {
+  //             errorDispatch({
+  //               type: "CHECK_WORD_ERROR",
+  //               payload: true
+  //             });
+  //             errorDispatch({
+  //               type: "SET_WORD_ERROR_MESSAGE",
+  //               payload: "実際に存在する単語を入力してください。"
+  //             });
+  //             return;
+  //           }
+  //           if (!tokens[0].reading) {
+  //             errorDispatch({
+  //               type: "CHECK_WORD_ERROR",
+  //               payload: true
+  //             });
+  //             errorDispatch({
+  //               type: "SET_WORD_ERROR_MESSAGE",
+  //               payload: "認識できませんでした。別の単語を入力してください。"
+  //             });
+  //             return;
+  //           }
+  //           let reading: string = tokens[0].reading;
+  //           const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
+  //             const chr = match.charCodeAt(0) - 0x60;
+  //             return String.fromCharCode(chr);
+  //           });
+  //           resolve(hiragana);
+  //         }
+  //       })
+  //     })
+  //   }
+
+  //   if(state.inputWord){
+  //     // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
+  //     console.log(state.inputWord);
+  //     changeToHiragana(state.inputWord)
+  //     .then((data: string): void => {
+  //       console.log(data);
+  //       hiraganaInputWord = data;
+  //     })
+  //     .then((): void => {
+  //       if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
+  //         dispatch(verifyJapaneseWord(true));
+  //         console.log("the input word can follow the previous word!");
+  //       };
+  //       if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
+  //         errorDispatch({
+  //           type: "CHECK_WORD_ERROR",
+  //           payload: true
+  //         });
+  //         errorDispatch({
+  //           type: "SET_WORD_ERROR_MESSAGE",
+  //           payload: "前の単語につながりません。"
+  //         });
+  //       };
+  //     })
+  //   }
+  // }
   
   useEffect(() => {
     // TODO: 現状の最後の単語をfetchするfunctionを入れる
@@ -113,11 +147,11 @@ const useHandleAction = () => {
 
   // TODO: 入力した単語をsetするfunction
 
-  return {
-    ...state,
-    handleWordChange: handleWordChange,
-    handleOnClick: handleOnClick
-  };
+  // return {
+  //   ...state,
+  //   handleWordChange: handleWordChange,
+  //   handleOnClick: handleOnClick
+  // };
 };
 
 export default useHandleAction;

--- a/web/src/pages/Play/hooks.ts
+++ b/web/src/pages/Play/hooks.ts
@@ -1,157 +1,161 @@
-import React, { useEffect, useReducer } from "react";
-import { actions, initialState, reducer } from "reducers/play";
-// import kuromoji from "kuromoji";
+import React from "react";
 
-const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
+// 本ファイルは使用していない
+// 了承確認後、削除予定
 
-const useHandleAction = () => {
-  const [state, dispatch] = useReducer(reducer, initialState);
+// import { actions, initialState, reducer } from "reducers/play";
+// // import kuromoji from "kuromoji";
+
+// const { setLastWord, setInputWord, verifyJapaneseWord, setError, checkWordError, setWordErrorMessage } = actions;
+
+// const useHandleAction = () => {
+//   const [state, dispatch] = useReducer(reducer, initialState);
   
 
-  // console.log(errorState.hasWordError);
+//   console.log(errorState.hasWordError);
 
-  // const handleWordChange = (input: string) => {
-  //   dispatch(setInputWord(input));
-  // };
+//   const handleWordChange = (input: string) => {
+//     dispatch(setInputWord(input));
+//   };
 
-  // const handleOnClick = () => {
-  //   let lastCharacter: string = state.lastWord.slice(-1);
-  //   let hiraganaInputWord: string = "";
+//   const handleOnClick = () => {
+//     let lastCharacter: string = state.lastWord.slice(-1);
+//     let hiraganaInputWord: string = "";
 
-  //   // 前の単語が特殊文字で終了する場合の最終文字の変形処理
-  //   if (state.lastWord) {
+//     // 前の単語が特殊文字で終了する場合の最終文字の変形処理
+//     if (state.lastWord) {
       
-  //     if (lastCharacter === 'ー') {
-  //       lastCharacter = state.lastWord.slice(0, -1).slice(-1);
-  //     }
-  //     switch(lastCharacter) {
-  //       case 'ぁ':
-  //           lastCharacter = 'あ';
-  //           break;
-  //       case 'ぃ':
-  //           lastCharacter = 'い';
-  //           break;
-  //       case 'ぅ':
-  //           lastCharacter = 'う';
-  //           break;
-  //       case 'ぇ':
-  //           lastCharacter = 'え';
-  //           break;
-  //       case 'ぉ':
-  //           lastCharacter = 'お';
-  //           break;
-  //       case 'っ':
-  //           lastCharacter = 'つ';
-  //           break;
-  //       case 'ゃ':
-  //           lastCharacter = 'や';
-  //           break;
-  //       case 'ゅ':
-  //           lastCharacter = 'ゆ';
-  //           break;
-  //       case 'ょ':
-  //           lastCharacter = 'よ';
-  //           break;
-  //       case 'ゎ':
-  //           lastCharacter = 'わ';
-  //           break;
-  //       default:
-  //     }
-  //   }
+//       if (lastCharacter === 'ー') {
+//         lastCharacter = state.lastWord.slice(0, -1).slice(-1);
+//       }
+//       switch(lastCharacter) {
+//         case 'ぁ':
+//             lastCharacter = 'あ';
+//             break;
+//         case 'ぃ':
+//             lastCharacter = 'い';
+//             break;
+//         case 'ぅ':
+//             lastCharacter = 'う';
+//             break;
+//         case 'ぇ':
+//             lastCharacter = 'え';
+//             break;
+//         case 'ぉ':
+//             lastCharacter = 'お';
+//             break;
+//         case 'っ':
+//             lastCharacter = 'つ';
+//             break;
+//         case 'ゃ':
+//             lastCharacter = 'や';
+//             break;
+//         case 'ゅ':
+//             lastCharacter = 'ゆ';
+//             break;
+//         case 'ょ':
+//             lastCharacter = 'よ';
+//             break;
+//         case 'ゎ':
+//             lastCharacter = 'わ';
+//             break;
+//         default:
+//       }
+//     }
 
-  //   // kuromojiを使って入力単語をひらがなに変換する処理
-  //   const changeToHiragana = (text: string) => {
-  //     return new Promise<string> ((resolve, reject) => {
-  //       kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
-  //         if(error){
-  //           reject(error);
-  //           return;
-  //         } else {
-  //           const tokens: any[] = tokenizer.tokenize(text);
-  //           console.log(tokens);
-  //           if (tokens.length === 0 || tokens.length > 1) {
-  //             errorDispatch({
-  //               type: "CHECK_WORD_ERROR",
-  //               payload: true
-  //             });
-  //             errorDispatch({
-  //               type: "SET_WORD_ERROR_MESSAGE",
-  //               payload: "一単語だけ入力してください。"
-  //             });
-  //             console.log("呼ばれたよ");
-  //             return;
-  //           }
-  //           if (tokens[0].word_type === 'UNKNOWN') {
-  //             errorDispatch({
-  //               type: "CHECK_WORD_ERROR",
-  //               payload: true
-  //             });
-  //             errorDispatch({
-  //               type: "SET_WORD_ERROR_MESSAGE",
-  //               payload: "実際に存在する単語を入力してください。"
-  //             });
-  //             return;
-  //           }
-  //           if (!tokens[0].reading) {
-  //             errorDispatch({
-  //               type: "CHECK_WORD_ERROR",
-  //               payload: true
-  //             });
-  //             errorDispatch({
-  //               type: "SET_WORD_ERROR_MESSAGE",
-  //               payload: "認識できませんでした。別の単語を入力してください。"
-  //             });
-  //             return;
-  //           }
-  //           let reading: string = tokens[0].reading;
-  //           const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
-  //             const chr = match.charCodeAt(0) - 0x60;
-  //             return String.fromCharCode(chr);
-  //           });
-  //           resolve(hiragana);
-  //         }
-  //       })
-  //     })
-  //   }
+//     // kuromojiを使って入力単語をひらがなに変換する処理
+//     const changeToHiragana = (text: string) => {
+//       return new Promise<string> ((resolve, reject) => {
+//         kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
+//           if(error){
+//             reject(error);
+//             return;
+//           } else {
+//             const tokens: any[] = tokenizer.tokenize(text);
+//             console.log(tokens);
+//             if (tokens.length === 0 || tokens.length > 1) {
+//               errorDispatch({
+//                 type: "CHECK_WORD_ERROR",
+//                 payload: true
+//               });
+//               errorDispatch({
+//                 type: "SET_WORD_ERROR_MESSAGE",
+//                 payload: "一単語だけ入力してください。"
+//               });
+//               console.log("呼ばれたよ");
+//               return;
+//             }
+//             if (tokens[0].word_type === 'UNKNOWN') {
+//               errorDispatch({
+//                 type: "CHECK_WORD_ERROR",
+//                 payload: true
+//               });
+//               errorDispatch({
+//                 type: "SET_WORD_ERROR_MESSAGE",
+//                 payload: "実際に存在する単語を入力してください。"
+//               });
+//               return;
+//             }
+//             if (!tokens[0].reading) {
+//               errorDispatch({
+//                 type: "CHECK_WORD_ERROR",
+//                 payload: true
+//               });
+//               errorDispatch({
+//                 type: "SET_WORD_ERROR_MESSAGE",
+//                 payload: "認識できませんでした。別の単語を入力してください。"
+//               });
+//               return;
+//             }
+//             let reading: string = tokens[0].reading;
+//             const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
+//               const chr = match.charCodeAt(0) - 0x60;
+//               return String.fromCharCode(chr);
+//             });
+//             resolve(hiragana);
+//           }
+//         })
+//       })
+//     }
 
-  //   if(state.inputWord){
-  //     // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
-  //     console.log(state.inputWord);
-  //     changeToHiragana(state.inputWord)
-  //     .then((data: string): void => {
-  //       console.log(data);
-  //       hiraganaInputWord = data;
-  //     })
-  //     .then((): void => {
-  //       if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
-  //         dispatch(verifyJapaneseWord(true));
-  //         console.log("the input word can follow the previous word!");
-  //       };
-  //       if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
-  //         errorDispatch({
-  //           type: "CHECK_WORD_ERROR",
-  //           payload: true
-  //         });
-  //         errorDispatch({
-  //           type: "SET_WORD_ERROR_MESSAGE",
-  //           payload: "前の単語につながりません。"
-  //         });
-  //       };
-  //     })
-  //   }
-  // }
+//     if(state.inputWord){
+//       // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
+//       console.log(state.inputWord);
+//       changeToHiragana(state.inputWord)
+//       .then((data: string): void => {
+//         console.log(data);
+//         hiraganaInputWord = data;
+//       })
+//       .then((): void => {
+//         if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
+//           dispatch(verifyJapaneseWord(true));
+//           console.log("the input word can follow the previous word!");
+//         };
+//         if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
+//           errorDispatch({
+//             type: "CHECK_WORD_ERROR",
+//             payload: true
+//           });
+//           errorDispatch({
+//             type: "SET_WORD_ERROR_MESSAGE",
+//             payload: "前の単語につながりません。"
+//           });
+//         };
+//       })
+//     }
+//   }
   
-  useEffect(() => {
-    // TODO: 現状の最後の単語をfetchするfunctionを入れる
-  });
+//   useEffect(() => {
+//     // TODO: 現状の最後の単語をfetchするfunctionを入れる
+//   });
 
-  // TODO: 入力した単語をsetするfunction
+//   // TODO: 入力した単語をsetするfunction
 
-  // return {
-  //   ...state,
-  //   handleWordChange: handleWordChange,
-  //   handleOnClick: handleOnClick
-  // };
-};
+//   return {
+//     ...state,
+//     handleWordChange: handleWordChange,
+//     handleOnClick: handleOnClick
+//   };
+// };
 
-export default useHandleAction;
+// export default useHandleAction;

--- a/web/src/pages/Play/hooks.ts
+++ b/web/src/pages/Play/hooks.ts
@@ -62,57 +62,49 @@ const useHandleAction = () => {
       }
     }
 
-    if (state.inputWord) {
-      // kuromojiを使って入力単語をひらがなに変換する処理
-      const changeToHiragana = (text: string) => {
-        return new Promise<string>((resolve, reject) => {
-          kuromoji
-            .builder({ dicPath: "/dict" })
-            .build((error: Error, tokenizer: any) => {
-              if (error) {
-                reject(error);
-                return;
-              } else {
-                const tokens: any[] = tokenizer.tokenize(text);
-                console.log(tokens);
-                if (tokens.length === 0 || tokens.length > 1) {
-                  dispatch(checkWordError(true));
-                  dispatch(setWordErrorMessage("一単語だけ入力してください。"));
-                  return;
-                }
-                if (tokens[0].word_type === "UNKNOWN") {
-                  dispatch(checkWordError(true));
-                  dispatch(
-                    setWordErrorMessage(
-                      "実際に存在する単語を入力してください。"
-                    )
-                  );
-                  return;
-                }
-                if (!tokens[0].reading) {
-                  dispatch(checkWordError(true));
-                  dispatch(
-                    setWordErrorMessage(
-                      "認識できませんでした。別の単語を入力してください。"
-                    )
-                  );
-                  return;
-                }
-                let reading: string = tokens[0].reading;
-                const hiragana: string = reading.replace(
-                  /[\u30a1-\u30f6]/g,
-                  function (match: string) {
-                    const chr = match.charCodeAt(0) - 0x60;
-                    return String.fromCharCode(chr);
-                  }
-                );
-                resolve(hiragana);
-              }
+    const changeToHiragana = (text: string) => {
+      return new Promise<string> ((resolve, reject) => {
+        kuromoji.builder({ dicPath: "/dict" }).build((error: Error, tokenizer: any) => {
+          if(error){
+            reject(error);
+            return;
+          } else {
+            const tokens: any[] = tokenizer.tokenize(text);
+            console.log(tokens);
+            if (tokens.length === 0 || tokens.length > 1) {
+              dispatch(checkWordError(true));
+              dispatch(setWordErrorMessage("一単語だけ入力してください。"));
+              return;
+            }
+            if (tokens[0].word_type === 'UNKNOWN') {
+              dispatch(checkWordError(true));
+              dispatch(setWordErrorMessage("実際に存在する単語を入力してください。"));
+              return;
+            }
+            if (!tokens[0].reading) {
+              dispatch(checkWordError(true));
+              dispatch(setWordErrorMessage("認識できませんでした。別の単語を入力してください。"));
+              return;
+            }
+            let reading: string = tokens[0].reading;
+            const hiragana: string = reading.replace(/[\u30a1-\u30f6]/g, function(match: string) {
+              const chr = match.charCodeAt(0) - 0x60;
+              return String.fromCharCode(chr);
             });
-        });
-      };
+            resolve(hiragana);
+          }
+        })
+      })
+    }
 
-      // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
+    // 入力が無い場合のエラー
+    if(!state.inputWord) {
+      dispatch(checkWordError(true));
+      dispatch(setWordErrorMessage("単語を入力してください。"));
+    }
+
+    // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
+    if(state.inputWord) {
       changeToHiragana(state.inputWord)
         .then((data: string): void => {
           console.log(data);

--- a/web/src/reducers/play.ts
+++ b/web/src/reducers/play.ts
@@ -2,6 +2,8 @@ const SET_LAST_WORD = "SET_LAST_WORD" as const;
 const SET_INPUT_WORD = "SET_INPUT_WORD" as const;
 const VERIFY_JAPANESE_WORD = "VERIFY_JAPANESE_WORD" as const;
 const SET_ERROR = "SET_ERROR" as const;
+const CHECK_WORD_ERROR = "CHECK_WORD_ERROR" as const;
+const SET_WORD_ERROR_MESSAGE = "SET_WORD_ERROR_MESSAGE" as const;
 
 const setLastWord = (word: string) => {
   return { type: SET_LAST_WORD, word: word };
@@ -19,24 +21,39 @@ const setError = (error?: Error) => {
   return { type: SET_ERROR, error: error };
 };
 
+const checkWordError = (hasWordError: boolean) => {
+  return { type: CHECK_WORD_ERROR, hasWordError: hasWordError };
+};
+
+const setWordErrorMessage = (wordErrorMessage: string) => {
+  return { type: SET_WORD_ERROR_MESSAGE, wordErrorMessage: wordErrorMessage };
+};
+
+
 export const actions = {
   setLastWord,
   setInputWord,
   verifyJapaneseWord,
   setError,
+  checkWordError,
+  setWordErrorMessage
 };
 
 export type Actions =
   | ReturnType<typeof setLastWord>
   | ReturnType<typeof setInputWord>
   | ReturnType<typeof verifyJapaneseWord>
-  | ReturnType<typeof setError>;
+  | ReturnType<typeof setError>
+  | ReturnType<typeof checkWordError>
+  | ReturnType<typeof setWordErrorMessage>;
 
 export type State = {
   lastWord: string;
   inputWord: string;
   isValidJapanese: boolean;
   error?: Error;
+  hasWordError: boolean;
+  wordErrorMessage: string;
 };
 
 export const initialState: State = {
@@ -44,6 +61,8 @@ export const initialState: State = {
   inputWord: "",
   isValidJapanese: false,
   error: undefined,
+  hasWordError: false,
+  wordErrorMessage: "",
 };
 
 export const reducer = (state: State, action: Actions): State => {
@@ -67,6 +86,16 @@ export const reducer = (state: State, action: Actions): State => {
       return {
         ...state,
         error: action.error,
+      };
+    case CHECK_WORD_ERROR:
+      return {
+        ...state,
+        hasWordError: action.hasWordError,
+      };
+    case SET_WORD_ERROR_MESSAGE:
+      return {
+        ...state,
+        wordErrorMessage: action.wordErrorMessage,
       };
     default:
       return state;

--- a/web/src/reducers/play.ts
+++ b/web/src/reducers/play.ts
@@ -29,14 +29,13 @@ const setWordErrorMessage = (wordErrorMessage: string) => {
   return { type: SET_WORD_ERROR_MESSAGE, wordErrorMessage: wordErrorMessage };
 };
 
-
 export const actions = {
   setLastWord,
   setInputWord,
   verifyJapaneseWord,
   setError,
   checkWordError,
-  setWordErrorMessage
+  setWordErrorMessage,
 };
 
 export type Actions =


### PR DESCRIPTION
エラーハンドリングを実装しました。
<img width="1799" alt="Screen Shot 2022-10-02 at 13 26 55" src="https://user-images.githubusercontent.com/83794734/193437946-c185b754-89db-4779-9f03-0bd668ef2bf9.png">

エラーハンドリングケースは、下記の通りです。
- 複数単語入力：一単語だけ入力してください。
- word_typeがUNKNOWN：実際に存在する単語を入力してください。
- kuromoji登録なし：認識できませんでした。別の単語を入力してください。
- 前の最後の文字と異なる：前の単語につながりません。
- 入力なし：単語を入力してください。

構成を変更していますので、discordにて説明いたします。