### PR TITLE
単語を入力する部分のplaceholderのバグ修正＋いくつかのDOM error 修正

### DIFF
--- a/web/src/components/Notification.tsx
+++ b/web/src/components/Notification.tsx
@@ -21,14 +21,14 @@ export const Notification = ({ process, onClickAction }: Props) => {
           xmlns="http://www.w3.org/2000/svg"
           fill="none"
           viewBox="0 0 24 24"
-          stroke-width="1.5"
+          strokeWidth="1.5"
           stroke="currentColor"
           className="h-8 w-8 cursor-pointer"
           onClick={onClickAction}
         >
           <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
+            strokeLinecap="round"
+            strokeLinejoin="round"
             d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
           />
         </svg>

--- a/web/src/components/WordInput.tsx
+++ b/web/src/components/WordInput.tsx
@@ -1,3 +1,5 @@
+import { useTransformSpecialCharacter } from "hooks/useTransformSpecialCharacter";
+
 interface Props {
   onChangeAction: (input: string) => void;
   lastWord: string;
@@ -5,14 +7,14 @@ interface Props {
 
 export const WordInput = ({ onChangeAction, lastWord }: Props) => {
   return (
-    <div className='mt-5'>
+    <div className="mt-5">
       <input
         onChange={(e) => onChangeAction(e.currentTarget.value)}
-        type='text'
-        className='h-20 w-80 border-b-2 border-transparent border-b-accent bg-transparent px-4 font-nico text-xl focus:border-accent focus:ring-0 md:w-96'
-        placeholder={`「${
-          lastWord[lastWord.length - 1]
-        }」に続く単語を入れよう！`}
+        type="text"
+        className="h-20 w-80 border-b-2 border-transparent border-b-accent bg-transparent px-4 font-nico text-xl focus:border-accent focus:ring-0 md:w-96"
+        placeholder={`「${useTransformSpecialCharacter(
+          lastWord
+        )}」に続く単語を入れよう！`}
       />
     </div>
   );

--- a/web/src/components/WordInput.tsx
+++ b/web/src/components/WordInput.tsx
@@ -6,15 +6,14 @@ interface Props {
 }
 
 export const WordInput = ({ onChangeAction, lastWord }: Props) => {
+  const lastCharacter = useTransformSpecialCharacter(lastWord);
   return (
     <div className="mt-5">
       <input
         onChange={(e) => onChangeAction(e.currentTarget.value)}
         type="text"
         className="h-20 w-80 border-b-2 border-transparent border-b-accent bg-transparent px-4 font-nico text-xl focus:border-accent focus:ring-0 md:w-96"
-        placeholder={`「${useTransformSpecialCharacter(
-          lastWord
-        )}」に続く単語を入れよう！`}
+        placeholder={`「${lastCharacter}」に続く単語を入れよう！`}
       />
     </div>
   );

--- a/web/src/hooks/useTransformSpecialCharacter.ts
+++ b/web/src/hooks/useTransformSpecialCharacter.ts
@@ -1,0 +1,43 @@
+export const useTransformSpecialCharacter = (lastWord: string): string => {
+  let lastCharacter = lastWord.slice(-1);
+  if (lastCharacter === "ー") {
+    lastCharacter = lastWord.slice(0, -1).slice(-1);
+  } else {
+    switch (lastCharacter) {
+      case "ぁ":
+        lastCharacter = "あ";
+        break;
+      case "ぃ":
+        lastCharacter = "い";
+        break;
+      case "ぅ":
+        lastCharacter = "う";
+        break;
+      case "ぇ":
+        lastCharacter = "え";
+        break;
+      case "ぉ":
+        lastCharacter = "お";
+        break;
+      case "っ":
+        lastCharacter = "つ";
+        break;
+      case "ゃ":
+        lastCharacter = "や";
+        break;
+      case "ゅ":
+        lastCharacter = "ゆ";
+        break;
+      case "ょ":
+        lastCharacter = "よ";
+        break;
+      case "ゎ":
+        lastCharacter = "わ";
+        break;
+      default:
+        lastCharacter = lastWord.slice(-1);
+    }
+  }
+
+  return lastCharacter;
+};

--- a/web/src/pages/Play/Play.tsx
+++ b/web/src/pages/Play/Play.tsx
@@ -55,9 +55,9 @@ const Play = () => {
                 lastWord={lastWord}
               />
               {hasWordError && (
-                <p className="mt-5 text-left text-red-500 md:text-xl">
+                <div className="mt-5 text-left text-red-500 md:text-xl">
                   {errorTexts}
-                </p>
+                </div>
               )}
               <Button text={"つなげる"} onClick={handleOnClick} />
             </>

--- a/web/src/pages/Play/hooks.ts
+++ b/web/src/pages/Play/hooks.ts
@@ -24,6 +24,8 @@ const maxLength = 5;
 
 const useHandleAction = () => {
   const [state, dispatch] = useReducer(reducer, initialState);
+  // 前の単語が特殊文字で終了する場合の最終文字の変形処理
+  const lastCharacter = useTransformSpecialCharacter(state.lastWord);
 
   const handleWordChange = (input: string) => {
     dispatch(checkWordError(false));
@@ -35,9 +37,6 @@ const useHandleAction = () => {
     if (state.lastWord) {
       dispatch(setLoading(true));
       let hiraganaInputWord: string = "";
-
-      // 前の単語が特殊文字で終了する場合の最終文字の変形処理
-      const lastCharacter = useTransformSpecialCharacter(state.lastWord);
 
       const changeToHiragana = (text: string) => {
         return new Promise<string>((resolve, reject) => {
@@ -58,6 +57,7 @@ const useHandleAction = () => {
                       "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
                     )
                   );
+                  dispatch(setInputWord(""));
                   return;
                 }
                 if (tokens[0].word_type === "UNKNOWN") {
@@ -68,6 +68,7 @@ const useHandleAction = () => {
                       "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
                     )
                   );
+                  dispatch(setInputWord(""));
                   return;
                 }
                 if (!tokens[0].reading) {
@@ -78,6 +79,7 @@ const useHandleAction = () => {
                       "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
                     )
                   );
+                  dispatch(setInputWord(""));
                   return;
                 }
                 let reading: string = tokens[0].reading;
@@ -97,7 +99,9 @@ const useHandleAction = () => {
       // 入力が無い場合のエラー
       if (!state.inputWord) {
         dispatch(checkWordError(true));
+        dispatch(setLoading(false));
         dispatch(setWordErrorMessage("単語を入力してください。"));
+        return;
       }
       // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
       if (state.inputWord) {
@@ -112,6 +116,7 @@ const useHandleAction = () => {
               dispatch(
                 setWordErrorMessage("6文字以上の単語は入力できません。")
               );
+              dispatch(setInputWord(""));
               dispatch(setLoading(false));
               return;
             }
@@ -122,6 +127,7 @@ const useHandleAction = () => {
                   "最後が「ん」で終わる単語は入力できません。"
                 )
               );
+              dispatch(setInputWord(""));
               dispatch(setLoading(false));
               return;
             }
@@ -142,6 +148,7 @@ const useHandleAction = () => {
             if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
               dispatch(checkWordError(true));
               dispatch(setWordErrorMessage("前の単語につながりません。"));
+              dispatch(setInputWord(""));
               dispatch(setLoading(false));
             }
           });

--- a/web/src/pages/Play/hooks.ts
+++ b/web/src/pages/Play/hooks.ts
@@ -6,6 +6,7 @@ import { encode, decode } from "constants/encodeDecode";
 import { contractAddress } from "constants/contract";
 import { ethers } from "ethers";
 import abi from "../../utils/Shiritori.json";
+import { useTransformSpecialCharacter } from "hooks/useTransformSpecialCharacter";
 
 const {
   setLastWord,
@@ -31,152 +32,120 @@ const useHandleAction = () => {
   };
 
   const handleOnClick = async () => {
-    dispatch(setLoading(true));
-    let lastCharacter: string = state.lastWord.slice(-1);
-    let hiraganaInputWord: string = "";
-
-    // 前の単語が特殊文字で終了する場合の最終文字の変形処理
     if (state.lastWord) {
-      if (lastCharacter === "ー") {
-        lastCharacter = state.lastWord.slice(0, -1).slice(-1);
-      }
-      switch (lastCharacter) {
-        case "ぁ":
-          lastCharacter = "あ";
-          break;
-        case "ぃ":
-          lastCharacter = "い";
-          break;
-        case "ぅ":
-          lastCharacter = "う";
-          break;
-        case "ぇ":
-          lastCharacter = "え";
-          break;
-        case "ぉ":
-          lastCharacter = "お";
-          break;
-        case "っ":
-          lastCharacter = "つ";
-          break;
-        case "ゃ":
-          lastCharacter = "や";
-          break;
-        case "ゅ":
-          lastCharacter = "ゆ";
-          break;
-        case "ょ":
-          lastCharacter = "よ";
-          break;
-        case "ゎ":
-          lastCharacter = "わ";
-          break;
-        default:
-      }
-    }
+      dispatch(setLoading(true));
+      let hiraganaInputWord: string = "";
 
-    const changeToHiragana = (text: string) => {
-      return new Promise<string>((resolve, reject) => {
-        kuromoji
-          .builder({ dicPath: "/dict" })
-          .build((error: Error, tokenizer: any) => {
-            if (error) {
-              reject(error);
-              return;
-            } else {
-              const tokens: any[] = tokenizer.tokenize(text);
-              console.log(tokens);
-              if (tokens.length === 0 || tokens.length > 1) {
-                dispatch(checkWordError(true));
-                dispatch(setLoading(false));
-                dispatch(
-                  setWordErrorMessage(
-                    "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
-                  )
-                );
+      // 前の単語が特殊文字で終了する場合の最終文字の変形処理
+      const lastCharacter = useTransformSpecialCharacter(state.lastWord);
+
+      const changeToHiragana = (text: string) => {
+        return new Promise<string>((resolve, reject) => {
+          kuromoji
+            .builder({ dicPath: "/dict" })
+            .build((error: Error, tokenizer: any) => {
+              if (error) {
+                reject(error);
                 return;
-              }
-              if (tokens[0].word_type === "UNKNOWN") {
-                dispatch(checkWordError(true));
-                dispatch(setLoading(false));
-                dispatch(
-                  setWordErrorMessage(
-                    "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
-                  )
-                );
-                return;
-              }
-              if (!tokens[0].reading) {
-                dispatch(checkWordError(true));
-                dispatch(setLoading(false));
-                dispatch(
-                  setWordErrorMessage(
-                    "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
-                  )
-                );
-                return;
-              }
-              let reading: string = tokens[0].reading;
-              const hiragana: string = reading.replace(
-                /[\u30a1-\u30f6]/g,
-                function (match: string) {
-                  const chr = match.charCodeAt(0) - 0x60;
-                  return String.fromCharCode(chr);
+              } else {
+                const tokens: any[] = tokenizer.tokenize(text);
+                console.log(tokens);
+                if (tokens.length === 0 || tokens.length > 1) {
+                  dispatch(checkWordError(true));
+                  dispatch(setLoading(false));
+                  dispatch(
+                    setWordErrorMessage(
+                      "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
+                    )
+                  );
+                  return;
                 }
+                if (tokens[0].word_type === "UNKNOWN") {
+                  dispatch(checkWordError(true));
+                  dispatch(setLoading(false));
+                  dispatch(
+                    setWordErrorMessage(
+                      "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
+                    )
+                  );
+                  return;
+                }
+                if (!tokens[0].reading) {
+                  dispatch(checkWordError(true));
+                  dispatch(setLoading(false));
+                  dispatch(
+                    setWordErrorMessage(
+                      "単語が認識できませんでした。以下のことを試してください。\n-　ひらがなとカタカナを入れ替える（×: ごりら、◯: ゴリラ）\n-　複数単語の場合は一単語にする（×: ごまだんご、◯: ごま）\n-　別の単語を入力する"
+                    )
+                  );
+                  return;
+                }
+                let reading: string = tokens[0].reading;
+                const hiragana: string = reading.replace(
+                  /[\u30a1-\u30f6]/g,
+                  function (match: string) {
+                    const chr = match.charCodeAt(0) - 0x60;
+                    return String.fromCharCode(chr);
+                  }
+                );
+                resolve(hiragana);
+              }
+            });
+        });
+      };
+
+      // 入力が無い場合のエラー
+      if (!state.inputWord) {
+        dispatch(checkWordError(true));
+        dispatch(setWordErrorMessage("単語を入力してください。"));
+      }
+      // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
+      if (state.inputWord) {
+        changeToHiragana(state.inputWord)
+          .then((data: string): void => {
+            console.log("changeToHiragana", data);
+            hiraganaInputWord = data;
+          })
+          .then(async (): Promise<void> => {
+            if (hiraganaInputWord.length > 5) {
+              dispatch(checkWordError(true));
+              dispatch(
+                setWordErrorMessage("6文字以上の単語は入力できません。")
               );
-              resolve(hiragana);
+              dispatch(setLoading(false));
+              return;
+            }
+            if (hiraganaInputWord.slice(-1) === "ん") {
+              dispatch(checkWordError(true));
+              dispatch(
+                setWordErrorMessage(
+                  "最後が「ん」で終わる単語は入力できません。"
+                )
+              );
+              dispatch(setLoading(false));
+              return;
+            }
+            // 成功の場合ここにくる
+            if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
+              console.log("hiraganaInputWord", hiraganaInputWord);
+
+              dispatch(verifyJapaneseWord(true));
+              console.log("hiraganaInputWord", hiraganaInputWord);
+              const wordNum = encode(hiraganaInputWord, maxLength);
+              console.log("decoded", decode(wordNum, maxLength));
+
+              console.log("the input word can follow the previous word!");
+
+              await mint(hiraganaInputWord, wordNum);
+            }
+            console.log("lastCharactoer", lastCharacter);
+            if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
+              dispatch(checkWordError(true));
+              dispatch(setWordErrorMessage("前の単語につながりません。"));
+              dispatch(setLoading(false));
             }
           });
-      });
-    };
-
-    // 入力が無い場合のエラー
-    if (!state.inputWord) {
-      dispatch(checkWordError(true));
-      dispatch(setWordErrorMessage("単語を入力してください。"));
-    }
-    // 前の単語の最終語句と続いているか確認し、繋がっていればstateをtrueに変更する
-    if (state.inputWord) {
-      changeToHiragana(state.inputWord)
-        .then((data: string): void => {
-          console.log("changeToHiragana", data);
-          hiraganaInputWord = data;
-        })
-        .then(async (): Promise<void> => {
-          if (hiraganaInputWord.length > 5) {
-            dispatch(checkWordError(true));
-            dispatch(setWordErrorMessage("6文字以上の単語は入力できません。"));
-            dispatch(setLoading(false));
-            return;
-          }
-          if (hiraganaInputWord.slice(-1) === "ん") {
-            dispatch(checkWordError(true));
-            dispatch(
-              setWordErrorMessage("最後が「ん」で終わる単語は入力できません。")
-            );
-            dispatch(setLoading(false));
-            return;
-          }
-          // 成功の場合ここにくる
-          if (lastCharacter === hiraganaInputWord.slice(0, 1)) {
-            console.log("hiraganaInputWord", hiraganaInputWord);
-
-            dispatch(verifyJapaneseWord(true));
-            console.log("hiraganaInputWord", hiraganaInputWord);
-            const wordNum = encode(hiraganaInputWord, maxLength);
-            console.log("decoded", decode(wordNum, maxLength));
-
-            console.log("the input word can follow the previous word!");
-
-            await mint(hiraganaInputWord, wordNum);
-          }
-          console.log("lastCharactoer", lastCharacter);
-          if (lastCharacter !== hiraganaInputWord.slice(0, 1)) {
-            dispatch(checkWordError(true));
-            dispatch(setWordErrorMessage("前の単語につながりません。"));
-            dispatch(setLoading(false));
-          }
-        });
+      }
     }
   };
 
@@ -290,6 +259,8 @@ const useHandleAction = () => {
       currentWordNum: currentWordNum,
       tokenId: id,
     };
+
+    console.log(body, ">>>");
     const response = await window.fetch(
       `${import.meta.env.VITE_API_URL}/generate`,
       {
@@ -320,7 +291,7 @@ const useHandleAction = () => {
       dispatch(
         setMintProcess({
           show: true,
-          message: "WalletでConfirmを押すとミントが始まります！",
+          message: "WalletでAcceptを押すとミントが始まります！",
         })
       );
       const isMinted = await mintNFT(


### PR DESCRIPTION
フロント側の単語を入力するplaceholderについて、
単語の最後の文字が特殊文字だった場合が考慮されていなかったのでそれを修正しました。

以前：クーラー　=> `「ー」に続く単語を入れよう！`　になってしまっていた。
修正後：クーラー　=> `「ら」に続く単語を入れよう！`

上記を修正するにあたり、既存の特殊文字のチェックをカスタムフックとして作成し、使いまわせるようにしました。

そのほかに、フロント側で出ていたいくつかのDOMエラーを解消しました。

テスト方法：
- 単語をフロントから繋げてみてコンソールに特にエラーが出ないことを確認＋単語がちゃんと繋がるか確認（できれば特殊文字で終わる単語でテストする）
