### PR TITLE
Metamask以外のウォレットをクリックしたときにQRコードが表示されないバグを修正しました

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { LoadingSpinner } from "components/Spinner";
 
 import "./index.css";
 import "@rainbow-me/rainbowkit/styles.css";
+import "./polyfills";
 
 import {
   getDefaultWallets,


### PR DESCRIPTION
Viteを使う場合、`polyfill.ts`をrainbowkitの例に従って定義していたが、それを`App.tsx` にインポートする必要があったことを見逃していた！

参考にしたもの↓
https://github.com/rainbow-me/rainbowkit/blob/main/examples/with-vite/src/main.tsx#L1

テスト：

MetaMask以外のウォレットでログインしてみる　→ 手っ取り早いのはMetaMaskのモバイル持っていたらWalletConnect経由でログインしてみる